### PR TITLE
Add microtonal keyboard with per-key pitch control

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useCallback, useRef } from "react";
 import "./App.css";
 import SamplePiano from "./Components/SamplePiano";
+import MicrotonalPiano from "./Components/MicrotonalPiano";
 import { useSearchHistory } from "./hooks/useSearchHistory";
 import RecentlyGenerated from "./Components/RecentlyGeneratedComponents/RecentlyGenerated";
 import CompoundSearch from "./Components/FormComponents/CompoundSearch";
@@ -289,17 +290,15 @@ function App() {
 
                 <div className="tabs tabs-lift tabs-sm mb-4">
                   <button
-                    className={`tab ${
-                      inputMode === "massbank" ? "tab-active" : ""
-                    }`}
+                    className={`tab ${inputMode === "massbank" ? "tab-active" : ""
+                      }`}
                     onClick={() => setInputMode("massbank")}
                   >
                     MassBank
                   </button>
                   <button
-                    className={`tab ${
-                      inputMode === "custom" ? "tab-active" : ""
-                    }`}
+                    className={`tab ${inputMode === "custom" ? "tab-active" : ""
+                      }`}
                     onClick={() => setInputMode("custom")}
                   >
                     Custom
@@ -383,7 +382,7 @@ function App() {
                 )}
               </div>
             </div>
-            {audioUrl && <SamplePiano audioUrl={audioUrl} />}
+            {audioUrl && <><SamplePiano audioUrl={audioUrl} /> <MicrotonalPiano audioUrl={audioUrl}/></>}
           </div>
           {/* column 3 - Search history */}
           <div className="order-3 lg:order-3">

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -389,14 +389,14 @@ function App() {
               <>
                 <SamplePiano audioUrl={audioUrl} />
                 <div className="collapse collapse-arrow bg-base-200 mt-4 max-w-[440px] mx-auto text-center">
-  <input 
-    type="checkbox" 
-    checked={microtonalOpen} 
-    onChange={() => setMicrotonalOpen(!microtonalOpen)} 
-  />
-  <div className="collapse-title font-medium after:!right-[calc(50%-80px)]">
-    Microtonal Keyboard
-  </div>
+                  <input
+                    type="checkbox"
+                    checked={microtonalOpen}
+                    onChange={() => setMicrotonalOpen(!microtonalOpen)}
+                  />
+                  <div className="collapse-title font-medium after:!right-[calc(50%-80px)]">
+                    Microtonal Keyboard
+                  </div>
                   <div className="collapse-content">
                     {microtonalOpen && (
                       <MicrotonalPiano

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -388,17 +388,24 @@ function App() {
             {audioUrl && (
               <>
                 <SamplePiano audioUrl={audioUrl} />
-                <div>
-                  <button onClick={() => setMicrotonalOpen(!microtonalOpen)}>
-                    {microtonalOpen ? 'Hide' : 'Show'} Microtonal Keyboard
-                  </button>
-                  {microtonalOpen && (
-                    <MicrotonalPiano
-                      audioUrl={audioUrl}
-                      pitchRatios={pitchRatios}
-                      setPitchRatios={setPitchRatios}
-                    />
-                  )}
+                <div className="collapse collapse-arrow bg-base-200 mt-4 max-w-[440px] mx-auto text-center">
+  <input 
+    type="checkbox" 
+    checked={microtonalOpen} 
+    onChange={() => setMicrotonalOpen(!microtonalOpen)} 
+  />
+  <div className="collapse-title font-medium after:!right-[calc(50%-80px)]">
+    Microtonal Keyboard
+  </div>
+                  <div className="collapse-content">
+                    {microtonalOpen && (
+                      <MicrotonalPiano
+                        audioUrl={audioUrl}
+                        pitchRatios={pitchRatios}
+                        setPitchRatios={setPitchRatios}
+                      />
+                    )}
+                  </div>
                 </div>
               </>
             )}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -52,6 +52,9 @@ function App() {
   const [inputMode, setInputMode] = useState<"massbank" | "custom">("massbank");
   const [spectrumText, setSpectrumText] = useState<string>("");
 
+  const [pitchRatios, setPitchRatios] = useState<number[]>(Array(13).fill(1.0));
+  const [microtonalOpen, setMicrotonalOpen] = useState(false);
+
   const handleFetch = useCallback(async () => {
     // Validation based on input mode
     if (inputMode === "massbank" && !compound.trim()) {
@@ -382,7 +385,23 @@ function App() {
                 )}
               </div>
             </div>
-            {audioUrl && <><SamplePiano audioUrl={audioUrl} /> <MicrotonalPiano audioUrl={audioUrl}/></>}
+            {audioUrl && (
+              <>
+                <SamplePiano audioUrl={audioUrl} />
+                <div>
+                  <button onClick={() => setMicrotonalOpen(!microtonalOpen)}>
+                    {microtonalOpen ? 'Hide' : 'Show'} Microtonal Keyboard
+                  </button>
+                  {microtonalOpen && (
+                    <MicrotonalPiano
+                      audioUrl={audioUrl}
+                      pitchRatios={pitchRatios}
+                      setPitchRatios={setPitchRatios}
+                    />
+                  )}
+                </div>
+              </>
+            )}
           </div>
           {/* column 3 - Search history */}
           <div className="order-3 lg:order-3">

--- a/frontend/src/Components/MicrotonalPiano.tsx
+++ b/frontend/src/Components/MicrotonalPiano.tsx
@@ -76,20 +76,24 @@ export default function MicrotonalPiano({
       />
       <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', marginTop: '16px' }}>
         {pitchRatios.map((ratio, index) => (
-          <input
-            key={index}
-            type="range"
-            min={0.25}
-            max={4}
-            step={0.01}
-            value={ratio}
-            onChange={(e) => {
-              const newRatios = [...pitchRatios];
-              newRatios[index] = parseFloat(e.target.value);
-              setPitchRatios(newRatios);
-            }}
-            style={{ width: '100%' }}
-          />
+          <div key={index} style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <input
+              type="range"
+              min={0.25}
+              max={4}
+              step={0.01}
+              value={ratio}
+              onChange={(e) => {
+                const newRatios = [...pitchRatios];
+                newRatios[index] = parseFloat(e.target.value);
+                setPitchRatios(newRatios);
+              }}
+              style={{ flex: 1 }}
+            />
+            <span style={{ width: '60px', textAlign: 'right' }}>
+              {Math.round(1200 * Math.log2(ratio))}¢
+            </span>
+          </div>
         ))}
       </div>
     </div>

--- a/frontend/src/Components/MicrotonalPiano.tsx
+++ b/frontend/src/Components/MicrotonalPiano.tsx
@@ -2,9 +2,13 @@ import { useEffect, useState } from "react";
 import { Piano, KeyboardShortcuts, MidiNumbers } from "react-piano";
 import "react-piano/dist/styles.css";
 import * as Tone from "tone";
-import { type SamplePianoProps } from "../types";
+import { type MicrotonalPianoProps } from "../types";
 
-export default function SamplePiano({ audioUrl }: SamplePianoProps) {
+export default function MicrotonalPiano({
+  audioUrl,
+  pitchRatios,
+  setPitchRatios
+}: MicrotonalPianoProps) {
   const [buffer, setBuffer] = useState<Tone.ToneAudioBuffer | null>(null);
   const [isInputFocused, setIsInputFocused] = useState(false);
 
@@ -15,9 +19,6 @@ export default function SamplePiano({ audioUrl }: SamplePianoProps) {
     lastNote,
     keyboardConfig: KeyboardShortcuts.HOME_ROW,
   });
-  const [pitchRatios, setPitchRatios] = useState<number[]>(
-    Array(13).fill(1.0)
-  );
 
   useEffect(() => {
     if (audioUrl) {
@@ -73,7 +74,7 @@ export default function SamplePiano({ audioUrl }: SamplePianoProps) {
         stopNote={() => { }}
         keyboardShortcuts={isInputFocused ? undefined : keyboardShortcuts}
       />
-      <div style={{ display: 'flex', gap: '4px', marginTop: '16px' }}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', marginTop: '16px' }}>
         {pitchRatios.map((ratio, index) => (
           <input
             key={index}
@@ -87,7 +88,7 @@ export default function SamplePiano({ audioUrl }: SamplePianoProps) {
               newRatios[index] = parseFloat(e.target.value);
               setPitchRatios(newRatios);
             }}
-            style={{ width: '30px' }}
+            style={{ width: '100%' }}
           />
         ))}
       </div>

--- a/frontend/src/Components/MicrotonalPiano.tsx
+++ b/frontend/src/Components/MicrotonalPiano.tsx
@@ -15,6 +15,9 @@ export default function SamplePiano({ audioUrl }: SamplePianoProps) {
     lastNote,
     keyboardConfig: KeyboardShortcuts.HOME_ROW,
   });
+  const [pitchRatios, setPitchRatios] = useState<number[]>(
+    Array(13).fill(1.0)
+  );
 
   useEffect(() => {
     if (audioUrl) {
@@ -56,9 +59,8 @@ export default function SamplePiano({ audioUrl }: SamplePianoProps) {
       fadeOut: 0.01,
     }).connect(gain);
 
-    const baseMidi = 60; // Middle C
-    const semitoneShift = midiNumber - baseMidi;
-    player.playbackRate = Math.pow(2, semitoneShift / 12);
+    const index = midiNumber - 60;
+    player.playbackRate = pitchRatios[index];
     player.start();
   };
 
@@ -68,9 +70,27 @@ export default function SamplePiano({ audioUrl }: SamplePianoProps) {
         width="440"
         noteRange={{ first: firstNote, last: lastNote }}
         playNote={playNote}
-        stopNote={() => {}}
+        stopNote={() => { }}
         keyboardShortcuts={isInputFocused ? undefined : keyboardShortcuts}
       />
+      <div style={{ display: 'flex', gap: '4px', marginTop: '16px' }}>
+        {pitchRatios.map((ratio, index) => (
+          <input
+            key={index}
+            type="range"
+            min={0.25}
+            max={4}
+            step={0.01}
+            value={ratio}
+            onChange={(e) => {
+              const newRatios = [...pitchRatios];
+              newRatios[index] = parseFloat(e.target.value);
+              setPitchRatios(newRatios);
+            }}
+            style={{ width: '30px' }}
+          />
+        ))}
+      </div>
     </div>
   );
 }

--- a/frontend/src/Components/MicrotonalPiano.tsx
+++ b/frontend/src/Components/MicrotonalPiano.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useState } from "react";
+import { Piano, KeyboardShortcuts, MidiNumbers } from "react-piano";
+import "react-piano/dist/styles.css";
+import * as Tone from "tone";
+import { type SamplePianoProps } from "../types";
+
+export default function SamplePiano({ audioUrl }: SamplePianoProps) {
+  const [buffer, setBuffer] = useState<Tone.ToneAudioBuffer | null>(null);
+  const [isInputFocused, setIsInputFocused] = useState(false);
+
+  const firstNote = MidiNumbers.fromNote("C4");
+  const lastNote = MidiNumbers.fromNote("C5");
+  const keyboardShortcuts = KeyboardShortcuts.create({
+    firstNote,
+    lastNote,
+    keyboardConfig: KeyboardShortcuts.HOME_ROW,
+  });
+
+  useEffect(() => {
+    if (audioUrl) {
+      const buffer = new Tone.ToneAudioBuffer({
+        url: audioUrl,
+        onload: () => {
+          setBuffer(buffer);
+        },
+        onerror: (err) => {
+          console.error("Buffer load error:", err);
+        },
+      });
+    }
+  }, [audioUrl]);
+
+  useEffect(() => {
+    const compoundInput = document.getElementById("compoundInput");
+
+    const handleFocus = () => setIsInputFocused(true);
+    const handleBlur = () => setIsInputFocused(false);
+
+    compoundInput?.addEventListener("focus", handleFocus);
+    compoundInput?.addEventListener("blur", handleBlur);
+
+    return () => {
+      compoundInput?.removeEventListener("focus", handleFocus);
+      compoundInput?.removeEventListener("blur", handleBlur);
+    };
+  }, []);
+
+  const playNote = (midiNumber: number) => {
+    if (!buffer) return;
+
+    const gain = new Tone.Gain(0.2).toDestination();
+
+    const player = new Tone.Player({
+      url: buffer,
+      fadeIn: 0.01,
+      fadeOut: 0.01,
+    }).connect(gain);
+
+    const baseMidi = 60; // Middle C
+    const semitoneShift = midiNumber - baseMidi;
+    player.playbackRate = Math.pow(2, semitoneShift / 12);
+    player.start();
+  };
+
+  return (
+    <div className="max-w-[440px] mt-6 mx-auto">
+      <Piano
+        width="440"
+        noteRange={{ first: firstNote, last: lastNote }}
+        playNote={playNote}
+        stopNote={() => {}}
+        keyboardShortcuts={isInputFocused ? undefined : keyboardShortcuts}
+      />
+    </div>
+  );
+}

--- a/frontend/src/Components/MicrotonalPiano.tsx
+++ b/frontend/src/Components/MicrotonalPiano.tsx
@@ -91,7 +91,11 @@ export default function MicrotonalPiano({
               style={{ flex: 1 }}
             />
             <span style={{ width: '60px', textAlign: 'right' }}>
-              {Math.round(1200 * Math.log2(ratio))}¢
+              {(() => {
+                const cents = Math.round(1200 * Math.log2(ratio));
+                if (cents === 0) return '0¢';
+                return `${cents > 0 ? '+' : ''}${cents}¢`;
+              })()}
             </span>
           </div>
         ))}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -103,6 +103,12 @@ export type SamplePianoProps = {
   audioUrl: string;
 };
 
+export interface MicrotonalPianoProps {
+  audioUrl: string;
+  pitchRatios: number[];
+  setPitchRatios: React.Dispatch<React.SetStateAction<number[]>>;
+}
+
 // =====================================
 // Display
 // =====================================


### PR DESCRIPTION
Adds a second keyboard where each key has its own pitch slider, allowing for microtonal tuning independent of 12-tone equal temperament.

13 sliders controlling playback rate (±2 octaves)
Real-time cents display
Collapsible UI
Values persist across audio generations