### PR TITLE
Capture traces and test-results in flake-detector

### DIFF
--- a/.github/workflows/flake-detector.yaml
+++ b/.github/workflows/flake-detector.yaml
@@ -126,6 +126,15 @@ jobs:
           path: tests/playwright/flake-report.json
           retention-days: 30
 
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: test-results
+          path: tests/playwright/test-results/
+          if-no-files-found: ignore
+          retention-days: 30
+
       - name: Cleanup
         if: always()
         run: docker compose down -v

--- a/tests/playwright/scripts/detect-flakes.mjs
+++ b/tests/playwright/scripts/detect-flakes.mjs
@@ -54,6 +54,8 @@ const result = spawnSync(
     ...passthroughArgs,
     `--repeat-each=${repeat}`,
     "--retries=0",
+    "--trace=retain-on-failure",
+    "--video=retain-on-failure",
     "--reporter=list,json",
   ],
   {

--- a/tests/playwright/scripts/detect-flakes.mjs
+++ b/tests/playwright/scripts/detect-flakes.mjs
@@ -55,7 +55,6 @@ const result = spawnSync(
     `--repeat-each=${repeat}`,
     "--retries=0",
     "--trace=retain-on-failure",
-    "--video=retain-on-failure",
     "--reporter=list,json",
   ],
   {


### PR DESCRIPTION
## Summary
- Add `--trace=retain-on-failure` to detect-flakes.mjs
- Upload `tests/playwright/test-results/` as a second artifact from the flake-detector workflow, with `if-no-files-found: ignore` so it's a no-op on green runs.