### PR TITLE
Remove background threading from log_compound_search

### DIFF
--- a/services/compound_service.py
+++ b/services/compound_service.py
@@ -1,4 +1,3 @@
-import threading
 from db import get_massbank_peaks, log_search
 
 
@@ -20,7 +19,4 @@ class CompoundDataService:
         }
 
     def log_compound_search(self, compound_name, accession):
-        """Log that a compound was searched (runs asynchronously)"""
-        threading.Thread(
-            target=log_search, args=(compound_name, accession), daemon=True
-        ).start()
+        log_search(compound_name, accession)


### PR DESCRIPTION
I had naively added threading to `log_compound_search` for a performance gain earlier on in this project, but it was over-engineering too early anyway, so turning it back to single-threaded.

My flake detection script caught a Playwright test in CI with a ~0.3% flake rate. The threading introduced a race condition, almost certainly the cause of the flake.

After the change I ran the flake detector ~1,000 times as a cheap way to verify it fixed the flake. Admittedly absurd for a side project, and a more deterministic path wouldn't be worth the effort. But had fun experimenting along the way.