### PR TITLE
log unhandled exceptions to stdout

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -16,23 +16,17 @@ notification_service = NotificationService()
 
 
 def history():
-    try:
-        limit = request.args.get("limit", default=20, type=int)
-        limit = max(1, min(limit, 100))
-        history_data = get_search_history(limit=limit)
-        return {"history": history_data}, 200
-    except Exception:
-        return {"error": "Internal server error"}, 500
+    limit = request.args.get("limit", default=20, type=int)
+    limit = max(1, min(limit, 100))
+    history_data = get_search_history(limit=limit)
+    return {"history": history_data}, 200
 
 
 def popular():
-    try:
-        limit = request.args.get("limit", default=20, type=int)
-        limit = max(1, min(limit, 100))
-        popular_data = get_popular_compounds(limit=limit)
-        return {"popular": popular_data}, 200
-    except Exception:
-        return {"error": "Internal server error"}, 500
+    limit = request.args.get("limit", default=20, type=int)
+    limit = max(1, min(limit, 100))
+    popular_data = get_popular_compounds(limit=limit)
+    return {"popular": popular_data}, 200
 
 
 def generate_audio_with_data(algorithm):
@@ -89,8 +83,6 @@ def generate_audio_with_data(algorithm):
             return {"error": error_msg}, 404
         else:
             return {"error": error_msg}, 400
-    except Exception:
-        return {"error": "Internal server error"}, 500
 
 
 def generate_audio_with_custom_data(algorithm):
@@ -143,5 +135,3 @@ def generate_audio_with_custom_data(algorithm):
 
     except ValueError as e:
         return {"error": str(e)}, 400
-    except Exception:
-        return {"error": "Internal server error"}, 500

--- a/app.py
+++ b/app.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import time
 
@@ -39,6 +40,11 @@ app = Flask(__name__, static_folder="static", static_url_path="")
 app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1)
 app.config["RATELIMIT_ENABLED"] = os.getenv("RATELIMIT_ENABLED", "true").lower() == "true"
 app.config["MAX_CONTENT_LENGTH"] = 200_000
+
+if __name__ != "__main__":
+    gunicorn_logger = logging.getLogger("gunicorn.error")
+    app.logger.handlers = gunicorn_logger.handlers
+    app.logger.setLevel(gunicorn_logger.level)
 
 CORS(app, resources={r"^/(massbank|custom|history|popular)(/.*)?$": {"origins": "*"}})
 

--- a/app.py
+++ b/app.py
@@ -7,6 +7,7 @@ from flask import Flask, jsonify, send_from_directory
 from flask_cors import CORS
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
+from werkzeug.exceptions import HTTPException
 from werkzeug.middleware.proxy_fix import ProxyFix
 
 from api import (
@@ -56,6 +57,14 @@ limiter = Limiter(
 
 audio_limit = limiter.limit("15 per minute")
 history_limit = limiter.shared_limit("30 per minute", scope="read-endpoints")
+
+
+@app.errorhandler(Exception)
+def handle_unexpected(e):
+    if isinstance(e, HTTPException):
+        return e
+    app.logger.exception("unhandled exception")
+    return jsonify({"error": "Internal server error"}), 500
 
 
 @app.errorhandler(429)


### PR DESCRIPTION
Replace four duplicated route-level `except Exception:` blocks with a central `errorhandler(Exception)` so uncaught exceptions get logged with stack via gunicorn's stdout stream instead of being silently swallowed.