### PR TITLE
log db errors via logger.exception

### DIFF
--- a/app.py
+++ b/app.py
@@ -44,8 +44,8 @@ app.config["MAX_CONTENT_LENGTH"] = 200_000
 
 if __name__ != "__main__":
     gunicorn_logger = logging.getLogger("gunicorn.error")
-    app.logger.handlers = gunicorn_logger.handlers
-    app.logger.setLevel(gunicorn_logger.level)
+    logging.getLogger().handlers = gunicorn_logger.handlers
+    logging.getLogger().setLevel(gunicorn_logger.level)
 
 CORS(app, resources={r"^/(massbank|custom|history|popular)(/.*)?$": {"origins": "*"}})
 

--- a/db/queries.py
+++ b/db/queries.py
@@ -1,4 +1,8 @@
+import logging
+
 from db import get_db_cursor
+
+logger = logging.getLogger(__name__)
 
 
 def log_search(compound, accession):
@@ -11,8 +15,8 @@ def log_search(compound, accession):
                 """,
                 (accession, compound),
             )
-    except Exception as e:
-        print(f"Failed to log search: {e}")
+    except Exception:
+        logger.exception("Failed to log search")
 
 
 def get_search_history(limit):
@@ -34,8 +38,8 @@ def get_search_history(limit):
                 {"accession": row[0], "compound": row[1], "created_at": row[2].isoformat()}
                 for row in rows
             ]
-    except Exception as e:
-        print(f"Failed to get recently generated compounds: {e}")
+    except Exception:
+        logger.exception("Failed to get recently generated compounds")
         return []
 
 
@@ -57,6 +61,6 @@ def get_popular_compounds(limit):
             rows = cursor.fetchall()
 
             return [{"compound": row[0], "search_count": row[1]} for row in rows]
-    except Exception as e:
-        print(f"Failed to get most generated compounds: {e}")
+    except Exception:
+        logger.exception("Failed to get most generated compounds")
         return []


### PR DESCRIPTION
Replace three `print()` calls in `db/queries.py` with `logger.exception()` so DB failures emit full tracebacks at ERROR level. Also moves the gunicorn-handler wiring in `app.py` from `app.logger` to the root logger, so module-level loggers (like the new `db.queries` one) inherit the same formatter via propagation instead of falling through to `logging.lastResort`.