### PR TITLE
add pyright and type audio module

### DIFF
--- a/.github/workflows/typecheck.yaml
+++ b/.github/workflows/typecheck.yaml
@@ -1,0 +1,29 @@
+name: Typecheck
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  typecheck-python:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt -r requirements-dev.txt
+
+      - name: Run Pyright
+        run: pyright

--- a/audio/__init__.py
+++ b/audio/__init__.py
@@ -5,6 +5,8 @@ Creates the audio file, and keeps track of data transformations.
 """
 
 from .audio_generation import (
+    Spectrum,
+    TransformedPeak,
     generate_combined_wav_bytes_and_data,
     generate_sine_wave,
     parse_spectrum_text,
@@ -16,6 +18,8 @@ from .frequency_algorithms import (
 )
 
 __all__ = [
+    "Spectrum",
+    "TransformedPeak",
     "generate_sine_wave",
     "generate_combined_wav_bytes_and_data",
     "parse_spectrum_text",

--- a/audio/audio_generation.py
+++ b/audio/audio_generation.py
@@ -31,7 +31,9 @@ from typing import TypedDict
 
 import numpy as np
 from numpy.typing import NDArray
-from scipy.io.wavfile import write  # pyright: ignore[reportMissingTypeStubs, reportUnknownVariableType]
+from scipy.io.wavfile import (  # pyright: ignore[reportMissingTypeStubs]
+    write,  # pyright: ignore[reportUnknownVariableType]
+)
 
 from .frequency_algorithms import (
     mz_to_frequency_inverse,

--- a/audio/audio_generation.py
+++ b/audio/audio_generation.py
@@ -27,9 +27,11 @@ Key NumPy Functions:
 
 import io
 import re
+from typing import TypedDict
 
 import numpy as np
-from scipy.io.wavfile import write
+from numpy.typing import NDArray
+from scipy.io.wavfile import write  # pyright: ignore[reportMissingTypeStubs, reportUnknownVariableType]
 
 from .frequency_algorithms import (
     mz_to_frequency_inverse,
@@ -37,8 +39,23 @@ from .frequency_algorithms import (
     mz_to_frequency_modulo,
 )
 
+Spectrum = list[tuple[float, float]]
 
-def generate_sine_wave(freq, intensity, time_array, wave_buffer):
+
+class TransformedPeak(TypedDict):
+    mz: float
+    frequency: float
+    intensity: float
+    amplitude_linear: float
+    amplitude_db: float
+
+
+def generate_sine_wave(
+    freq: float,
+    intensity: float,
+    time_array: NDArray[np.floating],
+    wave_buffer: NDArray[np.floating],
+) -> NDArray[np.floating]:
     """Generate sine wave into provided buffer (reusable array)"""
     working_scale = np.iinfo(np.int16).max * intensity
     np.sin(2 * np.pi * freq * time_array, out=wave_buffer)
@@ -47,7 +64,7 @@ def generate_sine_wave(freq, intensity, time_array, wave_buffer):
 
 
 def generate_combined_wav_bytes_and_data(
-    spectrum_data,
+    spectrum_data: Spectrum,
     offset: float = 300,
     scale: float = 100000,
     shift: float = 1,
@@ -58,7 +75,7 @@ def generate_combined_wav_bytes_and_data(
     modulus: float = 500,
     base: float = 100,
     hq: bool = False,
-):
+) -> tuple[io.BytesIO, list[TransformedPeak]]:
     # hq=True: float64 math + float32 WAV output (DAW-friendly precision, ~3x slower).
     # hq=False: float32 math + int16 WAV output (default; fast iteration).
     math_dtype = np.float64 if hq else np.float32
@@ -72,10 +89,10 @@ def generate_combined_wav_bytes_and_data(
     # Reusable buffer that gets overwritten for each peak
     sine_wave_buffer = np.zeros_like(time_array)
 
-    transformed_data = []
+    transformed_data: list[TransformedPeak] = []
 
     # Pre-normalize intensities to prevent huge numbers
-    max_intensity = max(intensity for mz, intensity in spectrum_data)
+    max_intensity = max(intensity for _, intensity in spectrum_data)
 
     for mz, intensity in spectrum_data:
         if algorithm == "linear":
@@ -131,7 +148,7 @@ def generate_combined_wav_bytes_and_data(
     return wav_buffer, transformed_data
 
 
-def parse_spectrum_text(text_input):
+def parse_spectrum_text(text_input: str) -> Spectrum:
     try:
         values = re.split(r"\s+", text_input.strip())
         float_values = [float(x) for x in values if x]
@@ -141,7 +158,7 @@ def parse_spectrum_text(text_input):
                 "Spectrum data must have an even number of values (pairs of mz/intensity)"
             )
 
-        spectrum_data = []
+        spectrum_data: Spectrum = []
         for i in range(0, len(float_values), 2):
             mz = float_values[i]
             intensity = float_values[i + 1]

--- a/audio/frequency_algorithms.py
+++ b/audio/frequency_algorithms.py
@@ -1,8 +1,8 @@
-def mz_to_frequency_linear(mz, offset: float = 300):
+def mz_to_frequency_linear(mz: float, offset: float = 300) -> float:
     return mz + offset
 
 
-def mz_to_frequency_inverse(mz, scale: float = 100000, shift: float = 1):
+def mz_to_frequency_inverse(mz: float, scale: float = 100000, shift: float = 1) -> float:
     if mz + shift == 0:
         raise ValueError(
             f"Inverse algorithm: peak at m/z={mz} with shift={shift} "
@@ -12,8 +12,8 @@ def mz_to_frequency_inverse(mz, scale: float = 100000, shift: float = 1):
 
 
 def mz_to_frequency_modulo(
-    mz, factor: float = 10, modulus: float = 500, base: float = 100
-):
+    mz: float, factor: float = 10, modulus: float = 500, base: float = 100
+) -> float:
     if modulus == 0:
         raise ValueError("Modulus cannot be zero.")
     return ((mz * factor) % modulus) + base

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,4 +12,4 @@ extend-select = ["I", "B", "S"]
 pythonVersion = "3.13"
 include = ["api", "audio", "db", "services", "utils", "app.py", "gunicorn.conf.py"]
 exclude = ["tests", "frontend", ".ruff_cache", "**/node_modules", "**/__pycache__"]
-strict = []
+strict = ["audio"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,3 +7,9 @@ extend-select = ["I", "B", "S"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["S101"]
+
+[tool.pyright]
+pythonVersion = "3.13"
+include = ["api", "audio", "db", "services", "utils", "app.py", "gunicorn.conf.py"]
+exclude = ["tests", "frontend", ".ruff_cache", "**/node_modules", "**/__pycache__"]
+strict = []

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ pytest==8.4.2
 pytest-cov==7.0.0
 mutmut==3.5.0
 ruff==0.15.12
+pyright==1.1.409


### PR DESCRIPTION
First slice of a multi-PR typing rollout. Pyright configured in basic mode globally, strict scoped to audio/.