### PR TITLE
reject non-positive intensities on /custom

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -16,6 +16,7 @@ from .validation import (
     AudioParametersBase,
     validate_algorithm,
     validate_and_parse_parameters,
+    validate_spectrum_peaks,
     validate_spectrum_text_range,
 )
 
@@ -146,6 +147,7 @@ def generate_audio_with_custom_data(algorithm: str) -> tuple[dict[str, Any], int
 
     try:
         spectrum = parse_spectrum_text(data["spectrum_text"])
+        validate_spectrum_peaks(spectrum)
 
         wav_buffer, transformed_data = generate_combined_wav_bytes_and_data(
             spectrum,

--- a/api/validation.py
+++ b/api/validation.py
@@ -143,3 +143,13 @@ def validate_and_parse_parameters(
 def validate_spectrum_text_range(text: str) -> None:
     if not (3 <= len(text) <= 100000):
         raise ValueError("Spectrum data must be between 3 and 100,000 characters.")
+
+
+def validate_spectrum_peaks(spectrum: list[tuple[float, float]]) -> None:
+    if not spectrum:
+        raise ValueError("Spectrum data contains no peaks")
+    for mz, intensity in spectrum:
+        if intensity <= 0:
+            raise ValueError(
+                f"Peak intensities must be greater than 0 (got {intensity} at m/z {mz})"
+            )

--- a/frontend/public/openapi.yaml
+++ b/frontend/public/openapi.yaml
@@ -499,6 +499,12 @@ components:
             spectrumTextFormat:
               value:
                 error: "Invalid spectrum data format: Spectrum data must have an even number of values (pairs of mz/intensity)"
+            spectrumNoPeaks:
+              value:
+                error: Spectrum data contains no peaks
+            spectrumNonPositiveIntensity:
+              value:
+                error: "Peak intensities must be greater than 0 (got -5.0 at m/z 50.0)"
             invalidType:
               value:
                 error: Invalid offset. Must be a float.

--- a/tests/integration/test_app.py
+++ b/tests/integration/test_app.py
@@ -246,3 +246,39 @@ def test_custom_endpoint_body_exceeds_max_content_length(client):
     assert response.status_code == 413
     data = response.get_json()
     assert data["error"] == "Request body too large"
+
+
+def test_custom_endpoint_non_positive_intensity(client):
+    response = client.post(
+        "/custom/linear",
+        json={"spectrum_text": "50 0\n80 100"},
+        content_type="application/json",
+    )
+
+    assert response.status_code == 400
+    data = response.get_json()
+    assert "Peak intensities must be greater than 0" in data["error"]
+
+
+def test_custom_endpoint_all_zero_intensity(client):
+    response = client.post(
+        "/custom/linear",
+        json={"spectrum_text": "50 0\n80 0"},
+        content_type="application/json",
+    )
+
+    assert response.status_code == 400
+    data = response.get_json()
+    assert "Peak intensities must be greater than 0" in data["error"]
+
+
+def test_custom_endpoint_whitespace_only_spectrum(client):
+    response = client.post(
+        "/custom/linear",
+        json={"spectrum_text": "   "},
+        content_type="application/json",
+    )
+
+    assert response.status_code == 400
+    data = response.get_json()
+    assert data["error"] == "Spectrum data contains no peaks"

--- a/tests/unit/test_api/test_validation.py
+++ b/tests/unit/test_api/test_validation.py
@@ -1,6 +1,7 @@
 from api.validation import (
     validate_algorithm,
     validate_and_parse_parameters,
+    validate_spectrum_peaks,
     validate_spectrum_text_range,
 )
 
@@ -411,3 +412,24 @@ def test_validate_spectrum_text_range_too_long():
         raise AssertionError("Expected ValueError to be raised")
     except ValueError as e:
         assert "Spectrum data must be between 3 and 100,000 characters." == str(e)
+
+
+# Validate spectrum peaks tests
+
+
+def test_validate_spectrum_peaks_empty():
+    try:
+        validate_spectrum_peaks([])
+        raise AssertionError("Expected ValueError to be raised")
+    except ValueError as e:
+        assert "Spectrum data contains no peaks" == str(e)
+
+
+def test_validate_spectrum_peaks_reports_first_offender():
+    try:
+        validate_spectrum_peaks([(50.0, 100.0), (80.0, 0.0), (90.0, -9.0)])
+        raise AssertionError("Expected ValueError to be raised")
+    except ValueError as e:
+        assert "Peak intensities must be greater than 0" in str(e)
+        assert "80" in str(e)
+        assert "90" not in str(e)


### PR DESCRIPTION
`/custom` validated spectrum length but not content, so three inputs broke the documented contract:

- intensity ≤ 0 beside a positive peak → `amplitude_db` serialized as `-Infinity` (invalid JSON; spec types it as `number`)
- all-zero intensities → `0/0` → `ZeroDivisionError` → 500
- whitespace-only `spectrum_text` → `"max() arg is an empty sequence"` leaked as the 400 body

Adds `validate_spectrum_peaks` (rejects empty + non-positive, 400 naming the offending peak), wired into `/custom` after parse. `/massbank` already filters these at the DB; `/custom` rejects rather than silently filters because the input is user-supplied. New 400s documented in `openapi.yaml`.