### PR TITLE
Retrieve accession with the most amount of peaks instead of first result

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ __pycache__/
 .env
 .coverage
 dev-commands.md
-*.sql
+db/mass_spectrum_db.sql
 .pytest_cache
 .DS_Store
 

--- a/db/init.sh
+++ b/db/init.sh
@@ -29,5 +29,8 @@ psql -v ON_ERROR_STOP=0 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" < /d
 # Kill the progress messages
 kill $PROGRESS_PID 2>/dev/null || true
 
+echo "Building derived tables..."
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" -f /migrations/001_accession_peak_counts.sql
+
 echo "🎉 Database initialization complete!"
 echo "Note: Some permission errors at the end are normal and can be ignored"

--- a/db/migrations/001_accession_peak_counts.sql
+++ b/db/migrations/001_accession_peak_counts.sql
@@ -1,0 +1,12 @@
+DROP TABLE IF EXISTS accession_peak_counts;
+
+CREATE TABLE accession_peak_counts AS
+SELECT accession, COUNT(*) AS peaks
+FROM (
+    SELECT DISTINCT accession, mz, intensity
+    FROM spectrum_data
+    WHERE intensity > 0
+) d
+GROUP BY accession;
+
+ALTER TABLE accession_peak_counts ADD PRIMARY KEY (accession);

--- a/db/render_massbank_queries.py
+++ b/db/render_massbank_queries.py
@@ -16,12 +16,13 @@ def get_massbank_peaks(compound_name: str) -> CompoundData:
     Two-step search like MassBank API: find compounds first, then get peaks
     """
     with get_db_cursor() as cursor:
-        # Step 1: Search the fast compound_accessions table (case-insensitive)
+        # Step 1: Resolve the name to its highest-peak accession
         search_query = """
-        SELECT accession, compound_name
-        FROM compound_accessions
-        WHERE LOWER(compound_name) = LOWER(%s)
-        ORDER BY accession
+        SELECT ca.accession, ca.compound_name
+        FROM compound_accessions ca
+        JOIN accession_peak_counts apc ON apc.accession = ca.accession
+        WHERE LOWER(ca.compound_name) = LOWER(%s)
+        ORDER BY apc.peaks DESC, ca.accession
         LIMIT 1
         """
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       - postgres_data:/var/lib/postgresql/data
       - ./db/mass_spectrum_db.sql:/docker-entrypoint-initdb.d/mass_spectrum_db.sql
       - ./db/init.sh:/docker-entrypoint-initdb.d/init.sh
+      - ./db/migrations:/migrations:ro
     healthcheck:
       test: ["CMD-SHELL", "psql -U massbank_user -d massbank -c 'SELECT COUNT(*) FROM spectrum_data;' 2>/dev/null | grep -E '^[[:space:]]*[1-9][0-9]{6}' || exit 1"] # wait for 7 digit number (millions of rows)
       interval: 60s

--- a/frontend/src/hooks/useSearchHistory.ts
+++ b/frontend/src/hooks/useSearchHistory.ts
@@ -20,13 +20,12 @@ export function useSearchHistory(limit: number = 100): UseSearchHistoryReturn {
 
       const data = await res.json();
 
-      // Deduplicate using accession as the unique identifier
       const seen = new Set<string>();
       const uniqueHistory = [];
 
       for (const entry of data.history) {
-        if (!seen.has(entry.accession)) {
-          seen.add(entry.accession);
+        if (!seen.has(entry.compound)) {
+          seen.add(entry.compound);
           uniqueHistory.push(entry);
         }
         if (uniqueHistory.length >= 20) break;

--- a/tests/integration/db/test_render_massbank_queries.py
+++ b/tests/integration/db/test_render_massbank_queries.py
@@ -1,6 +1,6 @@
 import pytest
 
-from db import get_massbank_peaks
+from db import get_db_cursor, get_massbank_peaks
 
 
 def test_get_massbank_peaks():
@@ -21,6 +21,21 @@ def test_get_massbank_peaks_case_insensitive():
     spectrum_lower = get_massbank_peaks("caffeine")["spectrum"]
     spectrum_upper = get_massbank_peaks("CAFFEINE")["spectrum"]
     assert spectrum_lower == spectrum_upper
+
+
+@pytest.mark.parametrize("compound", ["glucose", "aspirin", "biotin", "tryptophan"])
+def test_peak_count_table_matches_fetched_spectrum(compound):
+    data = get_massbank_peaks(compound)
+
+    with get_db_cursor() as cursor:
+        cursor.execute(
+            "SELECT peaks FROM accession_peak_counts WHERE accession = %s",
+            (data["accession"],),
+        )
+        row = cursor.fetchone()
+
+    assert row is not None
+    assert row[0] == len(data["spectrum"])
 
 
 # docker-compose exec app python -m pytest tests/ -v

--- a/tests/performance/test_audio_generation_performance.py
+++ b/tests/performance/test_audio_generation_performance.py
@@ -4,7 +4,39 @@ from audio import generate_combined_wav_bytes_and_data
 from db import get_massbank_peaks
 
 
-# audio generation 9 peaks
+# 8 peaks
+def test_benzoate_performance():
+    spectrum = get_massbank_peaks("benzoate")["spectrum"]
+
+    start_time = time.perf_counter()
+    _, transformation_data = generate_combined_wav_bytes_and_data(
+        spectrum, algorithm="linear"
+    )
+    end_time = time.perf_counter()
+    execution_time = end_time - start_time
+    print("benzoate: ", execution_time)
+
+    assert execution_time < 0.1
+    assert len(transformation_data) == len(spectrum)
+
+
+# 28 peaks
+def test_arginine_performance():
+    spectrum = get_massbank_peaks("arginine")["spectrum"]
+
+    start_time = time.perf_counter()
+    _, transformation_data = generate_combined_wav_bytes_and_data(
+        spectrum, algorithm="linear"
+    )
+    end_time = time.perf_counter()
+    execution_time = end_time - start_time
+    print("arginine: ", execution_time)
+
+    assert execution_time < 0.15
+    assert len(transformation_data) == len(spectrum)
+
+
+# 107 peaks
 def test_caffeine_performance():
     spectrum = get_massbank_peaks("caffeine")["spectrum"]
 
@@ -16,23 +48,7 @@ def test_caffeine_performance():
     execution_time = end_time - start_time
     print("caffeine: ", execution_time)
 
-    assert execution_time < 0.2
-    assert len(transformation_data) == len(spectrum)
-
-
-# 88 peaks
-def test_ajmalin_performance():
-    spectrum = get_massbank_peaks("Ajmalin")["spectrum"]
-
-    start_time = time.perf_counter()
-    _, transformation_data = generate_combined_wav_bytes_and_data(
-        spectrum, algorithm="linear"
-    )
-    end_time = time.perf_counter()
-    execution_time = end_time - start_time
-    print("Ajmalin: ", execution_time)
-
-    assert execution_time < 0.5
+    assert execution_time < 0.3
     assert len(transformation_data) == len(spectrum)
 
 
@@ -48,14 +64,29 @@ def test_cyclopyrroxanthin_performance():
     execution_time = end_time - start_time
     print("Cyclopyrroxanthin: ", execution_time)
 
-    assert execution_time < 9
+    assert execution_time < 4.5
     assert len(transformation_data) == len(spectrum)
 
 
-# HQ-mode (float64 math + float32 WAV) — bench medians: caffeine ~27ms,
-# Ajmalin ~220ms, Cyclopyrroxanthin ~4700ms. Thresholds set well above.
-def test_caffeine_hq_performance():
-    spectrum = get_massbank_peaks("caffeine")["spectrum"]
+# 10279 peaks
+def test_foetoside_c_performance():
+    spectrum = get_massbank_peaks("Foetoside C")["spectrum"]
+
+    start_time = time.perf_counter()
+    _, transformation_data = generate_combined_wav_bytes_and_data(
+        spectrum, algorithm="linear"
+    )
+    end_time = time.perf_counter()
+    execution_time = end_time - start_time
+    print("Foetoside C: ", execution_time)
+
+    assert execution_time < 25
+    assert len(transformation_data) == len(spectrum)
+
+
+# 28 peaks
+def test_arginine_hq_performance():
+    spectrum = get_massbank_peaks("arginine")["spectrum"]
 
     start_time = time.perf_counter()
     _, transformation_data = generate_combined_wav_bytes_and_data(
@@ -63,27 +94,13 @@ def test_caffeine_hq_performance():
     )
     end_time = time.perf_counter()
     execution_time = end_time - start_time
-    print("caffeine hq: ", execution_time)
+    print("arginine hq: ", execution_time)
 
-    assert execution_time < 0.5
+    assert execution_time < 0.3
     assert len(transformation_data) == len(spectrum)
 
 
-def test_ajmalin_hq_performance():
-    spectrum = get_massbank_peaks("Ajmalin")["spectrum"]
-
-    start_time = time.perf_counter()
-    _, transformation_data = generate_combined_wav_bytes_and_data(
-        spectrum, algorithm="linear", hq=True
-    )
-    end_time = time.perf_counter()
-    execution_time = end_time - start_time
-    print("Ajmalin hq: ", execution_time)
-
-    assert execution_time < 1.5
-    assert len(transformation_data) == len(spectrum)
-
-
+# 1933 peaks
 def test_cyclopyrroxanthin_hq_performance():
     spectrum = get_massbank_peaks("Cyclopyrroxanthin")["spectrum"]
 
@@ -95,5 +112,5 @@ def test_cyclopyrroxanthin_hq_performance():
     execution_time = end_time - start_time
     print("Cyclopyrroxanthin hq: ", execution_time)
 
-    assert execution_time < 18
+    assert execution_time < 14
     assert len(transformation_data) == len(spectrum)

--- a/tests/playwright/algorithm-switching.spec.ts
+++ b/tests/playwright/algorithm-switching.spec.ts
@@ -12,17 +12,16 @@ test.describe("Algorithm Switching", () => {
       name: "Modulo: ((mz * factor) % modulus) + base",
     });
 
-    // search for biotin (default linear) (clicking on most generated tag), search with enter key, verify first hz value
-    await page.getByText("BIOTIN").first().click();
+    await page.getByText("Choline").first().click();
     await waitForGenerate(page, () => page.locator("body").press("Enter"));
-    await expect(page.getByRole("cell", { name: "355.0534" })).toBeVisible();
+    await expect(page.getByRole("cell", { name: "404.1000" })).toBeVisible();
 
     await inverseRadio.check();
     await waitForGenerate(page, () => inverseRadio.press("Enter"));
-    await expect(page.getByRole("cell", { name: "406.3458" })).toBeVisible();
+    await expect(page.getByRole("cell", { name: "951.4748" })).toBeVisible();
 
     await moduloRadio.check();
     await waitForGenerate(page, () => moduloRadio.press("Enter"));
-    await expect(page.getByRole("cell", { name: "100.1820" })).toBeVisible();
+    await expect(page.getByRole("cell", { name: "141.0000" })).toBeVisible();
   });
 });

--- a/tests/playwright/compound-search.spec.ts
+++ b/tests/playwright/compound-search.spec.ts
@@ -2,59 +2,52 @@ import { test, expect } from "./fixtures";
 import { waitForGenerate } from "./test-helpers";
 
 test.describe("Compound Search", () => {
-  test("user can search for caffeine and generate audio", async ({
+  test("user can search for 3-Man2GlcNAc and generate audio", async ({
     page,
     compoundInput,
     generateButton,
   }) => {
     await test.step("search and generate", async () => {
       await compoundInput.click();
-      await compoundInput.fill("caffeine");
-      await expect(compoundInput).toHaveValue("caffeine");
+      await compoundInput.fill("3-Man2GlcNAc");
+      await expect(compoundInput).toHaveValue("3-Man2GlcNAc");
       await waitForGenerate(page, () => generateButton.click());
     });
 
     await test.step("spectrum and transformation tables", async () => {
       await expect(
-        page.getByRole("heading", { name: "Mass Spectrum Data (9 peaks)" })
+        page.getByRole("heading", { name: "Mass Spectrum Data (11 peaks)" })
       ).toBeVisible();
       await expect(
         page.getByRole("heading", { name: "Audio Transformation Data" })
       ).toBeVisible();
     });
 
-    await test.step("first/last peaks from both tables", async () => {
-      await expect(
-        page.getByRole("cell", { name: "56.0498", exact: true })
-      ).toBeVisible();
-      await expect(
-        page.getByRole("cell", { name: "5,501,836", exact: true })
-      ).toBeVisible();
-      await expect(
-        page.getByRole("cell", { name: "195.0877", exact: true })
-      ).toBeVisible();
-      await expect(
-        page.getByRole("cell", { name: "529,785,088", exact: true })
-      ).toBeVisible();
-      await expect(
-        page.getByRole("cell", { name: "356.0498", exact: true })
-      ).toBeVisible();
-      await expect(
-        page.getByRole("cell", { name: "-39.6718", exact: true })
-      ).toBeVisible();
-      await expect(
-        page.getByRole("cell", { name: "495.0877", exact: true })
-      ).toBeVisible();
-      await expect(
-        page.getByRole("cell", { name: "0.0000", exact: true })
-      ).toBeVisible();
+    await test.step("first row of each table", async () => {
+      const spectrumCells = page
+        .getByRole("table")
+        .first()
+        .locator("tbody tr")
+        .first()
+        .locator("td");
+      await expect(spectrumCells.nth(0)).toHaveText("324.8000");
+      await expect(spectrumCells.nth(1)).toHaveText("50,160");
+
+      const audioCells = page
+        .getByRole("table")
+        .nth(1)
+        .locator("tbody tr")
+        .first()
+        .locator("td");
+      await expect(audioCells.nth(0)).toHaveText("670.8000");
+      await expect(audioCells.nth(1)).toHaveText("0.0000");
     });
 
     await test.step("result metadata and audio player", async () => {
       await expect(page.getByText("Success!")).toBeVisible();
-      await expect(page.getByText("Compound: Caffeine")).toBeVisible();
+      await expect(page.getByText("Compound: 3-Man2GlcNAc")).toBeVisible();
       await expect(
-        page.getByText("Accession: MSBNK-ACES_SU-AS000088")
+        page.getByText("MSBNK-Fukuyama_Univ-FU000005")
       ).toBeVisible();
       await expect(
         page.getByRole("link", { name: "Download WAV" })


### PR DESCRIPTION
More peaks = more interesting. The original implementation resolved a compound name to the first available accession, which has worked well, but a name maps to many accessions and the first is often a sparse scan. This tries resolving to the accession with the most peaks instead.

Adds a precomputed `accession_peak_counts` table (peak count per accession) to keep the lookup fast.
