### PR TITLE
use same-origin API requests and trim docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,13 @@
 .git
 .github
+.env
+.ruff_cache
 node_modules
-__pycache__
-*.pyc
+**/__pycache__
+**/*.pyc
 *.md
 .coverage
+db/mass_spectrum_db.sql
 frontend/node_modules
 frontend/dist
 tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY frontend/package*.json ./
 RUN npm ci
 COPY frontend/ ./
 
-ARG VITE_API_URL=http://localhost:5000
+ARG VITE_API_URL=
 ENV VITE_API_URL=$VITE_API_URL
 RUN npm run build
 

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,1 +1,1 @@
-VITE_API_URL=https://mass-spectrum-to-audio-converter.onrender.com
+VITE_API_URL=


### PR DESCRIPTION
After this change deploys once, remove the VITE_API_URL environment variable from Render and rebuild; base-image verification intentionally uses -f docker-compose.yml to exclude the development override.